### PR TITLE
Updated ElasticMQ to 0.13.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.2
 FROM anapsix/alpine-java:8_server-jre
 
-ENV ELASTICMQ_VERSION 0.12.1
+ENV ELASTICMQ_VERSION 0.13.8
 EXPOSE 9324
 
 CMD ["java", "-jar", "-Dconfig.file=/elasticmq/custom.conf", "/elasticmq/server.jar"]


### PR DESCRIPTION
This commit updates the version of ElasticMQ from 0.12.1 to 0.13.8.

I've ran in to a few issues that have been fixed upstream and it'd be super helpful
if these were included in this image.